### PR TITLE
allow pdf to be loaded from a URL

### DIFF
--- a/src/Pdf.php
+++ b/src/Pdf.php
@@ -19,13 +19,13 @@ class Pdf
     protected $validOutputFormats = ['jpg', 'jpeg', 'png'];
 
     /**
-     * @param string $pdfFile The path to the pdffile.
+     * @param string $pdfFile The path or url to the pdffile.
      *
      * @throws \Spatie\PdfToImage\Exceptions\PdfDoesNotExist
      */
     public function __construct($pdfFile)
     {
-        if (! file_exists($pdfFile)) {
+        if (! filter_var($pdfFile, FILTER_VALIDATE_URL) && ! file_exists($pdfFile)) {
             throw new PdfDoesNotExist();
         }
 


### PR DESCRIPTION
The [Imagick ](http://php.net/manual/en/imagick.construct.php) class allows a file to be loaded from a URL. There is no check of the URL (other than if it's a valid format) to ensure that the file exists at the URL, it relies on the \Imagick exception to be thrown when a new class is instantiated.