### PR TITLE
Fix subtitle syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ $pdf->saveImage($pathToWhereImageShouldBeStored);
 If the path you pass to `saveImage` has the extensions  `jpg`, `jpeg`, or `png` the image will be saved in that format.
 Otherwise the output will be a jpg.
 
-##Other methods
+## Other methods
+
 You can get the total number of pages in the pdf:
 ```php
 $pdf->getNumberOfPages(); //returns an int


### PR DESCRIPTION
Slightly change to fix the incorrect rendering of a subtitle. See visual demo below.

---

**Before the fix**

##Other methods
You can get […]


---

**After the fix**

## Other methods

You can get […]