### PR TITLE
allow the layer method to be changed

### DIFF
--- a/src/Exceptions/InvalidLayerMethod.php
+++ b/src/Exceptions/InvalidLayerMethod.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Spatie\PdfToImage\Exceptions;
+
+class InvalidLayerMethod extends \Exception
+{
+}

--- a/src/Pdf.php
+++ b/src/Pdf.php
@@ -3,9 +3,9 @@
 namespace Spatie\PdfToImage;
 
 use Spatie\PdfToImage\Exceptions\InvalidFormat;
-use Spatie\PdfToImage\Exceptions\InvalidLayerMethod;
 use Spatie\PdfToImage\Exceptions\PdfDoesNotExist;
 use Spatie\PdfToImage\Exceptions\PageDoesNotExist;
+use Spatie\PdfToImage\Exceptions\InvalidLayerMethod;
 
 class Pdf
 {
@@ -75,7 +75,7 @@ class Pdf
     /**
      * Sets the layer method for \Imagicl::mergeImageLayers()
      * If int, should correspond to a predefined LAYERMETHOD constant.
-     * If null, \Imagicl::mergeImageLayers() will not be called
+     * If null, \Imagicl::mergeImageLayers() will not be called.
      *
      * @param int|null
      *
@@ -89,7 +89,7 @@ class Pdf
     public function setLayerMethod($layerMethod)
     {
         if (
-            is_integer($layerMethod) === false &&
+            is_int($layerMethod) === false &&
             is_null($layerMethod) === false
         ) {
             throw new InvalidLayerMethod('LayerMethod must be integer or null');
@@ -194,7 +194,7 @@ class Pdf
 
         $this->imagick->readImage(sprintf('%s[%s]', $this->pdfFile, $this->page - 1));
 
-        if (is_integer($this->layerMethod)) {
+        if (is_int($this->layerMethod)) {
             $this->imagick->mergeImageLayers($this->layerMethod);
         }
 


### PR DESCRIPTION
I was using this earlier, successfully generating PNGs & JPGs of a multi-page PDF to get an image back (had an initial issue due to installing a 64bit edition of ghostscript alongside 32bit php).

However, I found a problem when trying to set the resolution to get larger/smaller decodes, which may or may not be related to #36 ; on windows w/ php 7.1.1, the call to `Imagick::mergeImageLayers()` seems to reset the image resolution- this effect can be observed by peppering `Spatie\PdfToImage\Pdf::getImageData()` with calls to `Imagick::getImageWidth()`

In my particular case, I found that disabling the call to `Imagick::mergeImageLayers()` produced identical same output @ 72dpi (presumably no layers to merge), and the desired output @ different resolutions.

As a means of "fixing" the issue, I've gone and added a method for setting the layer method, defaulting it to `Imagick::LAYERMETHOD_FLATTEN` and using `null` to disable the call to `Imagick::mergeImageLayers()` entirely, fixing the resolution "bug" in my case, and possibly in #36 