### PR TITLE
Fix low resolution bug

### DIFF
--- a/src/Pdf.php
+++ b/src/Pdf.php
@@ -34,7 +34,7 @@ class Pdf
             throw new PdfDoesNotExist();
         }
 
-        $this->imagick = new \Imagick($pdfFile);
+        $this->imagick = new \Imagick();
         $this->pdfFile = $pdfFile;
     }
 


### PR DESCRIPTION
WHAT: Fixes a bug which causes converted PDFs to be read and outputed
as 72 DPI images, no matter what the resolution is set to.

![screen shot 2017-07-01 at 09 17 24](https://user-images.githubusercontent.com/1869424/27760014-2514501e-5e3e-11e7-9c6d-a40c72e31178.png) ![screen shot 2017-07-01 at 09 16 31](https://user-images.githubusercontent.com/1869424/27760004-0192cd5a-5e3e-11e7-8b9c-09139e841ad9.png)

WHY: Resolution of the Imagick object need to be set before reading the
file.

HOW: Fixed by not passing the filename to the Imagick constructor upon
newing it up, as the file is being read later on anyways. No need to
read the file twice!

References:
http://www.php.net/manual/en/imagick.setimageresolution.php#96182
http://www.php.net/manual/en/imagick.setresolution.php#95533