### PR TITLE
Bugfix number of pages

### DIFF
--- a/src/Pdf.php
+++ b/src/Pdf.php
@@ -38,6 +38,7 @@ class Pdf
         }
 
         $this->imagick = new Imagick($pdfFile);
+
         $this->numberOfPages = $this->imagick->getNumberImages();
 
         $this->pdfFile = $pdfFile;

--- a/src/Pdf.php
+++ b/src/Pdf.php
@@ -20,6 +20,8 @@ class Pdf
 
     protected $imagick;
 
+    protected $numberOfPages;
+
     protected $validOutputFormats = ['jpg', 'jpeg', 'png'];
 
     protected $layerMethod = Imagick::LAYERMETHOD_FLATTEN;
@@ -36,6 +38,7 @@ class Pdf
         }
 
         $this->imagick = new Imagick($pdfFile);
+        $this->numberOfPages = $this->imagick->getNumberImages();
 
         $this->pdfFile = $pdfFile;
     }
@@ -141,7 +144,7 @@ class Pdf
      */
     public function getNumberOfPages()
     {
-        return $this->imagick->getNumberImages();
+      return $this->numberOfPages;
     }
 
     /**


### PR DESCRIPTION
method getNumberOfPages returns false number of pages in multi-page pdf-files, cause class variable imagick will be overwritten in method getImageData. $this->imagick->getNumberImages() returns remaining pages of pdf instead of total count.

BTW: sorry for my bad english.