### PR TITLE
Improve remote processing performance

### DIFF
--- a/src/Exceptions/RemoteFileFetchFailed.php
+++ b/src/Exceptions/RemoteFileFetchFailed.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Spatie\PdfToImage\Exceptions;
+
+use Exception;
+
+class RemoteFileFetchFailed extends Exception
+{
+}

--- a/src/Exceptions/TempFileDoesNotExist.php
+++ b/src/Exceptions/TempFileDoesNotExist.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Spatie\PdfToImage\Exceptions;
+
+use Exception;
+
+class TempFileDoesNotExist extends Exception
+{
+}

--- a/src/Exceptions/TempPathNotWritable.php
+++ b/src/Exceptions/TempPathNotWritable.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Spatie\PdfToImage\Exceptions;
+
+use Exception;
+
+class TempPathNotWritable extends Exception
+{
+}

--- a/tests/PdfTest.php
+++ b/tests/PdfTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use Spatie\PdfToImage\Exceptions\InvalidFormat;
 use Spatie\PdfToImage\Exceptions\PdfDoesNotExist;
 use Spatie\PdfToImage\Exceptions\PageDoesNotExist;
+use Spatie\PdfToImage\Exceptions\RemoteFileFetchFailed;
 
 class PdfTest extends TestCase
 {
@@ -125,5 +126,12 @@ class PdfTest extends TestCase
             ->getImageData('test.jpg');
 
         $this->assertEquals(99, $imagick->getCompressionQuality());
+    }
+
+    /** @test */
+    public function it_will_throw_an_exception_when_try_to_fetch_non_existing_remote_file()
+    {
+        $this->expectException(RemoteFileFetchFailed::class);
+        new Pdf('https://pdfdoesnotexists.com/pdfdoesnotexists.pdf');
     }
 }


### PR DESCRIPTION
This PR main objective is enhance the remote file processing.
When a remote file with high number of pages is processed it takes huge time, because Imagick seems to process the whole file, and not just pages required.
We had facing a lot of troubles on own projects with saveImage first page of pdf, with > 300 pages, reaching more than 500 seconds for processing.
We have tested with this file:
https://www.rd.com.br/Download.aspx?Arquivo=g1va4C+5cfmJ7zPl9zlMTQ==
15MB 556pages
Time to save Image: 465 sec.

Then to fix it (or improve) we’ve updated the constructor to fetch remote file and process is as local.

Time do save Image after improvement: 59 sec.