### PR TITLE
Throw exception when setPage is called with a non-positive argument

### DIFF
--- a/src/Pdf.php
+++ b/src/Pdf.php
@@ -143,7 +143,7 @@ class Pdf
      */
     public function setPage($page)
     {
-        if ($page > $this->getNumberOfPages()) {
+        if ($page > $this->getNumberOfPages() || $page < 1) {
             throw new PageDoesNotExist("Page {$page} does not exist");
         }
 

--- a/tests/PdfTest.php
+++ b/tests/PdfTest.php
@@ -47,12 +47,15 @@ class PdfTest extends TestCase
         (new Pdf($this->testFile))->setOutputFormat('bla');
     }
 
-    /** @test */
-    public function it_will_throw_an_exception_when_passed_an_invalid_page()
+    /**
+     * @test
+     * @dataProvider invalid_page_number_provider
+     */
+    public function it_will_throw_an_exception_when_passed_an_invalid_page($invalidPage)
     {
         $this->expectException(PageDoesNotExist::class);
 
-        (new Pdf($this->testFile))->setPage(5);
+        (new Pdf($this->testFile))->setPage($invalidPage);
     }
 
     /** @test */
@@ -125,5 +128,10 @@ class PdfTest extends TestCase
             ->getImageData('test.jpg');
 
         $this->assertEquals(99, $imagick->getCompressionQuality());
+    }
+
+    public function invalid_page_number_provider()
+    {
+        return [[5], [0], [-1]];
     }
 }


### PR DESCRIPTION
Any attempt to save as an image would result in a cryptic GhostScript
command line error.