### PR TITLE
Don't instantiate Imagick in constructor

### DIFF
--- a/src/Pdf.php
+++ b/src/Pdf.php
@@ -37,7 +37,7 @@ class Pdf
 
         $this->imagick = new Imagick($pdfFile);
 
-        $this->numberOfPages = $this->imagick->getNumberImages();
+        $this->numberOfPages = $this->fetchNumberPages($pdfFile);
 
         $this->pdfFile = $pdfFile;
     }
@@ -214,5 +214,27 @@ class Pdf
         }
 
         return $outputFormat;
+    }
+
+    private function fetchNumberPages(string $pdfFile)
+    {
+        $stream = fopen($pdfFile, "r");
+        $content = fread($stream, filesize($pdfFile));
+
+        if(!$stream || !$content) {
+            throw new PdfDoesNotExist("File `{$pdfFile}` does not exist");
+        }
+
+        $count = 0;
+
+        $regex  = "/\/Count\s+(\d+)/";
+
+        if(preg_match_all($regex, $content, $matches)) {
+            $count = max($matches);
+
+            return $count[0];
+        } else {
+            throw new InvalidFormat('Cannot read page count from pdf');
+        }
     }
 }

--- a/src/Pdf.php
+++ b/src/Pdf.php
@@ -225,8 +225,6 @@ class Pdf
             throw new PdfDoesNotExist("File `{$pdfFile}` does not exist");
         }
 
-        $count = 0;
-
         $regex = "/\/Count\s+(\d+)/";
 
         if (preg_match_all($regex, $content, $matches)) {

--- a/src/Pdf.php
+++ b/src/Pdf.php
@@ -218,18 +218,18 @@ class Pdf
 
     private function fetchNumberPages(string $pdfFile)
     {
-        $stream = fopen($pdfFile, "r");
+        $stream = fopen($pdfFile, 'r');
         $content = fread($stream, filesize($pdfFile));
 
-        if(!$stream || !$content) {
+        if (! $stream || ! $content) {
             throw new PdfDoesNotExist("File `{$pdfFile}` does not exist");
         }
 
         $count = 0;
 
-        $regex  = "/\/Count\s+(\d+)/";
+        $regex = "/\/Count\s+(\d+)/";
 
-        if(preg_match_all($regex, $content, $matches)) {
+        if (preg_match_all($regex, $content, $matches)) {
             $count = max($matches);
 
             return $count[0];


### PR DESCRIPTION
This PR fixes #138 by adding a new method for fetching page count. It directly inspects pdf content.

Imagick instantiation is done without passing pdf file in constructor.