### PR TITLE
feat: added method fetchNumberPages that calc number of pages more faster and correctly

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
     ],
     "require": {
         "php" : "^7.2",
-        "ext-imagick" : "*"
+        "ext-imagick" : "*",
+        "smalot/pdfparser": "^0.14.0"
     },
     "require-dev": {
         "phpunit/phpunit" : "^8.0"

--- a/src/Pdf.php
+++ b/src/Pdf.php
@@ -3,6 +3,7 @@
 namespace Spatie\PdfToImage;
 
 use Imagick;
+use Smalot\PdfParser\Parser;
 use Spatie\PdfToImage\Exceptions\InvalidFormat;
 use Spatie\PdfToImage\Exceptions\PageDoesNotExist;
 use Spatie\PdfToImage\Exceptions\PdfDoesNotExist;
@@ -35,11 +36,20 @@ class Pdf
             throw new PdfDoesNotExist("File `{$pdfFile}` does not exist");
         }
 
-        $this->imagick = new Imagick($pdfFile);
+        $this->imagick = new Imagick();
 
-        $this->numberOfPages = $this->imagick->getNumberImages();
+        $this->numberOfPages = $this->fetchNumberPages($pdfFile);
 
         $this->pdfFile = $pdfFile;
+    }
+
+    public function fetchNumberPages(string $pdfFile)
+    {
+        $parser = new Parser();
+
+        $document = $parser->parseFile($pdfFile);
+
+        return count($document->getPages());
     }
 
     public function setResolution(int $resolution)

--- a/tests/PdfTest.php
+++ b/tests/PdfTest.php
@@ -18,6 +18,9 @@ class PdfTest extends TestCase
     protected $multipageTestFile;
 
     /** @var string */
+    protected $bigMultipageTestFile;
+
+    /** @var string */
     protected $remoteFileUrl;
 
     public function setUp(): void
@@ -27,6 +30,7 @@ class PdfTest extends TestCase
         $this->testFile = __DIR__.'/files/test.pdf';
 
         $this->multipageTestFile = __DIR__.'/files/multipage-test.pdf';
+        $this->bigMultipageTestFile = __DIR__.'/files/A17_FlightPlan.pdf';
 
         $this->remoteFileUrl = 'https://tcd.blackboard.com/webapps/dur-browserCheck-BBLEARN/samples/sample.pdf';
     }
@@ -64,6 +68,14 @@ class PdfTest extends TestCase
         $pdf = new Pdf($this->multipageTestFile);
 
         $this->assertTrue($pdf->getNumberOfPages() === 3);
+    }
+
+    /** @test */
+    public function it_will_quickly_parse_big_multipage_file()
+    {
+        $pdf = new Pdf($this->bigMultipageTestFile);
+
+        $this->assertTrue($pdf->getNumberOfPages() === 618);
     }
 
     /** @test */


### PR DESCRIPTION
## Problem with large file. #138

Imagick too long calculating number of pages and It turned out not always correctly(see test A17_FlightPlan.pdf). Server was down with 503 error on shared hosting because on that max execuution time 30s. I suggest parsing document with Smalot\PdfParser\Parser that work quickly and correctly.

### pdf document 40 pages
old
Time: 37.35 seconds, Memory: 4.00 MB
OK (1 test, 1 assertion)
Process finished with exit code 0
new
Time: 695 ms, Memory: 33.55 MB
OK (1 test, 1 assertion)
Process finished with exit code 0

### pdf document 618 pages
old
Failed asserting that false is true.
#wrong calc number of pages 370 instead of 618
Time: 34.77 seconds, Memory: 6.00 MB
FAILURES!
Tests: 1, Assertions: 1, Failures: 1.

new
Time: 20.79 seconds, Memory: 79.75 MB
OK (1 test, 1 assertion)
Process finished with exit code 0