### PR TITLE
Try to use ghostscript directly for page count

### DIFF
--- a/src/Pdf.php
+++ b/src/Pdf.php
@@ -218,7 +218,7 @@ class Pdf
     {
         $cmd = sprintf('gs -q -dNODISPLAY -c "(%s) (r) file runpdfbegin pdfpagecount = quit"', addslashes($pdfFile));
 
-        try{
+        try {
             $result = exec($cmd, $output, $return);
 
             if ($return === 0) {

--- a/src/Pdf.php
+++ b/src/Pdf.php
@@ -35,11 +35,7 @@ class Pdf
             throw new PdfDoesNotExist("File `{$pdfFile}` does not exist");
         }
 
-        $this->imagick = new Imagick();
-
-        $this->imagick->pingImage($pdfFile);
-
-        $this->numberOfPages = $this->imagick->getNumberImages();
+        $this->numberOfPages = $this->getPdfPageCount($pdfFile);
 
         $this->pdfFile = $pdfFile;
     }
@@ -216,5 +212,31 @@ class Pdf
         }
 
         return $outputFormat;
+    }
+
+    protected function getPdfPageCount(string $pdfFile): int
+    {
+        $cmd = sprintf('gs -q -dNODISPLAY -c "(%s) (r) file runpdfbegin pdfpagecount = quit"', addslashes($pdfFile));
+
+        try{
+            $result = exec($cmd, $output, $return);
+
+            if ($return === 0) {
+                return (int) $result;
+            }
+
+            return $this->getImagickPdfPageCount($pdfFile);
+        } catch (\Exception $e) {
+            return $this->getImagickPdfPageCount($pdfFile);
+        }
+    }
+
+    protected function getImagickPdfPageCount(string $pdfFile): int
+    {
+        $this->imagick = new Imagick();
+
+        $this->imagick->pingImage($pdfFile);
+
+        return $this->imagick->getNumberImages();
     }
 }

--- a/tests/PdfTest.php
+++ b/tests/PdfTest.php
@@ -122,6 +122,21 @@ class PdfTest extends TestCase
         $this->assertEquals(99, $imagick->getCompressionQuality());
     }
 
+    /** @test */
+    public function it_will_correctly_return_the_number_of_pages_in_pdf_with_imagick_file()
+    {
+        $reflection = new \ReflectionMethod(Pdf::class, 'getImagickPdfPageCount');
+        $reflection->setAccessible(true);
+
+        $mock = $this->getMockBuilder(Pdf::class)
+                     ->disableOriginalConstructor()
+                     ->getMock();
+
+        $count = $reflection->invokeArgs($mock, [$this->multipageTestFile]);
+
+        $this->assertTrue($count === 3);
+    }
+
     public function invalid_page_number_provider()
     {
         return [[5], [0], [-1]];


### PR DESCRIPTION
Using GhostScript directly is much faster than Imagick because it doesn't take a screenshot of every page as Imagick does. It faster even with a relatively small pdf with 2 pages.