### PR TITLE
Multiple pages overlapped into one image when pdf is loaded from url

### DIFF
--- a/src/Pdf.php
+++ b/src/Pdf.php
@@ -157,10 +157,6 @@ class Pdf
             $this->imagick->setCompressionQuality($this->compressionQuality);
         }
 
-        if (filter_var($this->pdfFile, FILTER_VALIDATE_URL)) {
-            return $this->getRemoteImageData($pathToImage);
-        }
-
         $this->imagick->readImage(sprintf('%s[%s]', $this->pdfFile, $this->page - 1));
 
         if (is_int($this->layerMethod)) {
@@ -184,21 +180,6 @@ class Pdf
         $this->compressionQuality = $compressionQuality;
 
         return $this;
-    }
-
-    protected function getRemoteImageData(string $pathToImage): Imagick
-    {
-        $this->imagick->readImage($this->pdfFile);
-
-        $this->imagick->setIteratorIndex($this->page - 1);
-
-        if (is_int($this->layerMethod)) {
-            $this->imagick = $this->imagick->mergeImageLayers($this->layerMethod);
-        }
-
-        $this->imagick->setFormat($this->determineOutputFormat($pathToImage));
-
-        return $this->imagick;
     }
 
     protected function determineOutputFormat(string $pathToImage): string


### PR DESCRIPTION
This PR fixes #180 by handling remote and local pdf the same way.

I'm not to sure why it was buggy, not a pro at imagick in any way, but by I've tested it and now both remote and local pdf work as expected. :)
