### PR TITLE
Adding a thumbnail method

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ You can set the quality of compression from 0 to 100:
 $pdf->setCompressionQuality(100); // sets the compression quality to maximum
 ```
 
+You can create a thumbnail of the pdf:
+```php
+$pdf->setThumbnailWidth(400)
+    ->saveImage($pathToWhereImageShouldBeStored);
+```
+
 ## Issues regarding Ghostscript
 
 This package uses Ghostscript through Imagick. For this to work Ghostscripts `gs` command should be accessible from the PHP process. For the PHP CLI process (e.g. Laravel's asynchronous jobs, commands, etc...) this is usually already the case. 

--- a/src/Pdf.php
+++ b/src/Pdf.php
@@ -29,6 +29,8 @@ class Pdf
 
     protected $compressionQuality;
 
+    protected $thumbnailWidth;
+
     public function __construct(string $pdfFile)
     {
         if (! file_exists($pdfFile)) {
@@ -120,7 +122,7 @@ class Pdf
         return file_put_contents($pathToImage, $imageData) !== false;
     }
 
-    public function saveAllPagesAsImages(string $directory, string $prefix = ''): array
+        public function saveAllPagesAsImages(string $directory, string $prefix = ''): array
     {
         $numberOfPages = $this->getNumberOfPages();
 
@@ -166,9 +168,13 @@ class Pdf
         if (is_int($this->layerMethod)) {
             $this->imagick = $this->imagick->mergeImageLayers($this->layerMethod);
         }
+        
+        if ($this->thumbnailWidth !== null) {
+            $this->imagick->thumbnailImage($this->thumbnailWidth, 0);
+        }
 
         $this->imagick->setFormat($this->determineOutputFormat($pathToImage));
-
+        
         return $this->imagick;
     }
 
@@ -182,6 +188,13 @@ class Pdf
     public function setCompressionQuality(int $compressionQuality)
     {
         $this->compressionQuality = $compressionQuality;
+
+        return $this;
+    }
+
+    public function setThumbnailWidth(int $thumbnailWidth)
+    {
+        $this->thumbnailWidth = $thumbnailWidth;
 
         return $this;
     }

--- a/tests/PdfTest.php
+++ b/tests/PdfTest.php
@@ -122,6 +122,17 @@ class PdfTest extends TestCase
         $this->assertEquals(99, $imagick->getCompressionQuality());
     }
 
+    /** @test */
+    public function it_will_create_a_thumbnail_at_specified_width()
+    {
+        $imagick = (new Pdf($this->multipageTestFile))
+            ->setThumbnailWidth(400)
+            ->getImageData('test.jpg')
+            ->getImageGeometry();
+
+        $this->assertEquals(400, $imagick['width']);
+    }
+
     public function invalid_page_number_provider()
     {
         return [[5], [0], [-1]];


### PR DESCRIPTION
Adding the ability to create thumbnails from a pdf.

```php
$pdf->setThumbnailWidth(400)
    ->saveImage($pathToWhereImageShouldBeStored);
```

I was looking for this feature in this package but didn't find it.
Hopefully others will find this helpful as well.

Cheers, Nathan.