### PR TITLE
Fix failing tests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,6 +15,11 @@ jobs:
         name: P${{ matrix.php }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 
         steps:
+            -   name: Upgrade ghostscript
+                run: |
+                    sudo apt-get update
+                    sudo apt-get install ghostscript
+
             - name: Checkout code
               uses: actions/checkout@v3
 

--- a/composer.json
+++ b/composer.json
@@ -37,5 +37,11 @@
     },
     "scripts": {
         "test": "vendor/bin/pest"
+    },
+    "config": {
+        "sort-packages": true,
+        "allow-plugins": {
+            "pestphp/pest-plugin": true
+        }
     }
 }

--- a/src/Pdf.php
+++ b/src/Pdf.php
@@ -43,8 +43,6 @@ class Pdf
         $this->imagick = new Imagick();
 
         $this->imagick->readImage($this->pdfFile);
-
-        $this->numberOfPages = $this->imagick->getNumberImages();
     }
 
     public function setResolution(int $resolution)
@@ -109,6 +107,10 @@ class Pdf
 
     public function getNumberOfPages(): int
     {
+        if ($this->numberOfPages === null) {
+            $this->numberOfPages = $this->imagick->getNumberImages();
+        }
+
         return $this->numberOfPages;
     }
 

--- a/src/Pdf.php
+++ b/src/Pdf.php
@@ -39,6 +39,12 @@ class Pdf
         }
 
         $this->pdfFile = $pdfFile;
+
+        $this->imagick = new Imagick();
+
+        $this->imagick->readImage($this->pdfFile);
+
+        $this->numberOfPages = $this->imagick->getNumberImages();
     }
 
     public function setResolution(int $resolution)
@@ -100,13 +106,9 @@ class Pdf
 
         return $this;
     }
-
+    
     public function getNumberOfPages(): int
     {
-        if ($this->numberOfPages === null) {
-            $this->numberOfPages = $this->imagick->getNumberImages();
-        }
-
         return $this->numberOfPages;
     }
 

--- a/src/Pdf.php
+++ b/src/Pdf.php
@@ -39,12 +39,6 @@ class Pdf
         }
 
         $this->pdfFile = $pdfFile;
-
-        $this->imagick = new Imagick();
-
-        $this->imagick->pingImage($pdfFile);
-
-        $this->numberOfPages = $this->imagick->getNumberImages();
     }
 
     public function setResolution(int $resolution)
@@ -109,6 +103,10 @@ class Pdf
 
     public function getNumberOfPages(): int
     {
+        if ($this->numberOfPages === null) {
+            $this->numberOfPages = $this->imagick->getNumberImages();
+        }
+
         return $this->numberOfPages;
     }
 

--- a/src/Pdf.php
+++ b/src/Pdf.php
@@ -106,7 +106,7 @@ class Pdf
 
         return $this;
     }
-    
+
     public function getNumberOfPages(): int
     {
         return $this->numberOfPages;


### PR DESCRIPTION
This PR adds the `pestphp/pest-plugin` composer plugin to the list of allowed plugins in the `composer.json` file.

It also updates the test workflow to use the latest ghostscript version, which was causing tests to fail (#198).  Also, this PR loads the PDF file after creating the `Imagick` instance.

Additionally, it implements some of the code from #199 to fix the failing tests:

- Remove usages of Imagick `pingImage` method as it is unreliable
- Lazy load `numberOfPages` until it is used

This PR should allow PRs #198 and #199 to be closed.

_id:allow-pest-plugin/v1_