### PR TITLE
Catch user attempting to convert directories.

### DIFF
--- a/src/Pdf.php
+++ b/src/Pdf.php
@@ -37,6 +37,10 @@ class Pdf
             throw new PdfDoesNotExist("File `{$pdfFile}` does not exist");
         }
 
+        if (! is_file($pdfFile)) {
+            throw new PdfDoesNotExist("Path `{$pdfFile}` exists but is not a file");
+        }
+
         $this->pdfFile = $pdfFile;
 
         $this->imagick = new Imagick();

--- a/tests/PdfTest.php
+++ b/tests/PdfTest.php
@@ -14,7 +14,11 @@ beforeEach(function () {
 
 it('will throw an exception when try to convert a non existing file', function () {
     new Pdf('pdfdoesnotexists.pdf');
-})->throws(PdfDoesNotExist::class);
+})->throws(PdfDoesNotExist::class, 'File `pdfdoesnotexists.pdf` does not exist');
+
+it('will throw an exception when try to convert a directory', function () {
+    new Pdf('.');
+})->throws(PdfDoesNotExist::class, 'Path `.` exists but is not a file');
 
 it('will throw an exception when trying to convert an invalid file type', function () {
     (new Pdf($this->testFile))->setOutputFormat('bla');


### PR DESCRIPTION
Currently, this library checks that the PDF file exists as a path, but it will still attempt to invoke Imagemagic if the path exists as a directory instead of a file.

This adds an extra check with about as clear a message as possible when it does not appear to be a file.

It looks like this should work for symbolic links too: https://www.php.net/manual/en/function.is-file.php#50742