### PR TITLE
Add PHP 8.3 to the test run workflow

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,7 +8,7 @@ jobs:
         strategy:
             fail-fast: true
             matrix:
-                php: [8.2, 8.1, 8.0, 7.4]
+                php: [8.3, 8.2, 8.1, 8.0, 7.4]
                 dependency-version: [prefer-lowest, prefer-stable]
                 os: [ubuntu-latest]
 


### PR DESCRIPTION
This PR adds PHP 8.3 to the test run workflow to ensure it's supported and works as expected.