### PR TITLE
Add resource limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,16 @@ $pdf->layerMethod(\Spatie\PdfToImage\Enums\LayerMethod::Merge);
 $pdf->layerMethod(\Spatie\PdfToImage\Enums\LayerMethod::None);
 ```
 
+Set resource limits for Imagick:
+
+```php
+// set memory limit to 128 MB:
+$pdf->resourceLimit(\Spatie\PdfToImage\Enums\ResourceLimitType::Memory, 134217728);
+
+// set thread limit to 4:
+$pdf->resourceLimit(\Spatie\PdfToImage\Enums\ResourceLimitType::Thread, 4);
+```
+
 ## Issues regarding Ghostscript
 
 This package uses Ghostscript through Imagick. For this to work Ghostscripts `gs` command should be accessible from the PHP process. For the PHP CLI process (e.g. Laravel's asynchronous jobs, commands, etc...) this is usually already the case. 
@@ -163,6 +173,8 @@ If you receive an error with the message `attempt to perform an operation not al
 ```xml
 <policy domain="coder" rights="read | write" pattern="PDF" />
 ```
+
+If you are experiencing failures without any error messages, you may need to increase the resource limits for Imagick. This can be done with the `resourceLimit` method.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -176,7 +176,12 @@ If you receive an error with the message `attempt to perform an operation not al
 <policy domain="coder" rights="read | write" pattern="PDF" />
 ```
 
-If you are experiencing failures without any error messages, you may need to increase the resource limits for Imagick. This can be done with the `resourceLimit` method.
+If you are experiencing failures without any error messages, you may need to increase the resource limits for Imagick. This can be done by modifying your `policy.xml` file. For example, to increase the memory limit to 128 MB and the thread limit to 4, you can add the following lines to your `policy.xml` file:
+
+```xml
+<policy domain="resource" name="memory" value="128MiB"/>
+<policy domain="resource" name="thread" value="4"/>
+```
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ $pdf->resourceLimit(\Spatie\PdfToImage\Enums\ResourceLimitType::Memory, 13421772
 $pdf->resourceLimit(\Spatie\PdfToImage\Enums\ResourceLimitType::Thread, 4);
 ```
 
+> When setting resource limits, Imagemagick may return success but will not set limits that exceed the values defined in your `policy.xml` file. 
+
 ## Issues regarding Ghostscript
 
 This package uses Ghostscript through Imagick. For this to work Ghostscripts `gs` command should be accessible from the PHP process. For the PHP CLI process (e.g. Laravel's asynchronous jobs, commands, etc...) this is usually already the case. 

--- a/src/Enums/ResourceLimitType.php
+++ b/src/Enums/ResourceLimitType.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Spatie\PdfToImage\Enums;
+
+use Imagick;
+
+enum ResourceLimitType: int
+{
+    case Area = Imagick::RESOURCETYPE_AREA;
+    case Disk = Imagick::RESOURCETYPE_DISK;
+    case File = Imagick::RESOURCETYPE_FILE;
+    case Map = Imagick::RESOURCETYPE_MAP;
+    case Memory = Imagick::RESOURCETYPE_MEMORY;
+    case Time = Imagick::RESOURCETYPE_TIME;
+    case Throttle = Imagick::RESOURCETYPE_THROTTLE;
+    case Thread = Imagick::RESOURCETYPE_THREAD;
+}

--- a/src/Pdf.php
+++ b/src/Pdf.php
@@ -7,6 +7,7 @@ use Spatie\PdfToImage\DTOs\PageSize;
 use Spatie\PdfToImage\DTOs\PdfPage;
 use Spatie\PdfToImage\Enums\LayerMethod;
 use Spatie\PdfToImage\Enums\OutputFormat;
+use Spatie\PdfToImage\Enums\ResourceLimitType;
 use Spatie\PdfToImage\Exceptions\InvalidLayerMethod;
 use Spatie\PdfToImage\Exceptions\InvalidQuality;
 use Spatie\PdfToImage\Exceptions\InvalidSize;
@@ -40,6 +41,8 @@ class Pdf
     protected ?int $resizeHeight = null;
 
     protected ?int $numberOfPages = null;
+
+    protected array $resourceLimits = [];
 
     public function __construct(string $filename)
     {
@@ -224,6 +227,12 @@ class Pdf
 
         $this->imagick->setResolution($this->resolution, $this->resolution);
 
+        if (! empty($this->resourceLimits)) {
+            foreach ($this->resourceLimits as [$type, $limit]) {
+                $this->imagick::setResourceLimit($type, $limit);
+            }
+        }
+
         if ($this->colorspace !== null) {
             $this->imagick->setColorspace($this->colorspace);
         }
@@ -315,6 +324,13 @@ class Pdf
 
         $this->resizeWidth = $width;
         $this->resizeHeight = $height ?? 0;
+
+        return $this;
+    }
+
+    public function resourceLimit(ResourceLimitType|int $type, int $limit): static
+    {
+        $this->resourceLimits[] = [$type instanceof ResourceLimitType ? $type->value : $type, $limit];
 
         return $this;
     }

--- a/tests/Unit/ResourceLimitsTest.php
+++ b/tests/Unit/ResourceLimitsTest.php
@@ -3,36 +3,40 @@
 use Spatie\PdfToImage\Enums\ResourceLimitType;
 use Spatie\PdfToImage\Pdf;
 
+beforeEach(function () {
+    $this->memory128MbInBytes = 134217728;
+});
+
 it('sets the area resource limit', function () {
     $pdf = new Pdf($this->testFile);
-    $im = $pdf->resourceLimit(ResourceLimitType::Area, 1024 * 1024 * 128)
+    $im = $pdf->resourceLimit(ResourceLimitType::Area, $this->memory128MbInBytes)
         ->getImageData($this->testFile, 1);
 
-    expect((int) $im::getResourceLimit(ResourceLimitType::Area->value))->toBeGreaterThanOrEqual((int) 1024 * 1024 * 128);
+    expect((int) $im::getResourceLimit(ResourceLimitType::Area->value))->toBeGreaterThanOrEqual($this->memory128MbInBytes);
 });
 
 it('sets the disk resource limit', function () {
     $pdf = new Pdf($this->testFile);
-    $im = $pdf->resourceLimit(ResourceLimitType::Disk, 1024 * 1024 * 128)
+    $im = $pdf->resourceLimit(ResourceLimitType::Disk, $this->memory128MbInBytes)
         ->getImageData($this->testFile, 1);
 
-    expect((int) $im::getResourceLimit(ResourceLimitType::Disk->value))->toBeGreaterThanOrEqual((int) 1024 * 1024 * 128);
+    expect((int) $im::getResourceLimit(ResourceLimitType::Disk->value))->toBeGreaterThanOrEqual($this->memory128MbInBytes);
 });
 
 it('sets the map resource limit', function () {
     $pdf = new Pdf($this->testFile);
-    $im = $pdf->resourceLimit(ResourceLimitType::Map, 1024 * 1024 * 128)
+    $im = $pdf->resourceLimit(ResourceLimitType::Map, $this->memory128MbInBytes)
         ->getImageData($this->testFile, 1);
 
-    expect((int) $im::getResourceLimit(ResourceLimitType::Map->value))->toBeGreaterThanOrEqual((int) 1024 * 1024 * 128);
+    expect((int) $im::getResourceLimit(ResourceLimitType::Map->value))->toBeGreaterThanOrEqual($this->memory128MbInBytes);
 });
 
 it('sets the memory resource limit', function () {
     $pdf = new Pdf($this->testFile);
-    $im = $pdf->resourceLimit(ResourceLimitType::Memory, 1024 * 1024 * 128)
+    $im = $pdf->resourceLimit(ResourceLimitType::Memory, $this->memory128MbInBytes)
         ->getImageData($this->testFile, 1);
 
-    expect((int) $im::getResourceLimit(ResourceLimitType::Memory->value))->toBeGreaterThanOrEqual((int) 1024 * 1024 * 128);
+    expect((int) $im::getResourceLimit(ResourceLimitType::Memory->value))->toBeGreaterThanOrEqual($this->memory128MbInBytes);
 });
 
 it('sets the time resource limit', function () {

--- a/tests/Unit/ResourceLimitsTest.php
+++ b/tests/Unit/ResourceLimitsTest.php
@@ -8,7 +8,7 @@ it('sets the area resource limit', function () {
     $im = $pdf->resourceLimit(ResourceLimitType::Area, 1024 * 1024 * 128)
         ->getImageData($this->testFile, 1);
 
-    expect((int) $im::getResourceLimit(ResourceLimitType::Area->value))->toBe((int) 1024 * 1024 * 128);
+    expect((int) $im::getResourceLimit(ResourceLimitType::Area->value))->toBeGreaterThanOrEqual((int) 1024 * 1024 * 128);
 });
 
 it('sets the disk resource limit', function () {
@@ -16,7 +16,7 @@ it('sets the disk resource limit', function () {
     $im = $pdf->resourceLimit(ResourceLimitType::Disk, 1024 * 1024 * 128)
         ->getImageData($this->testFile, 1);
 
-    expect((int) $im::getResourceLimit(ResourceLimitType::Disk->value))->toBe((int) 1024 * 1024 * 128);
+    expect((int) $im::getResourceLimit(ResourceLimitType::Disk->value))->toBeGreaterThanOrEqual((int) 1024 * 1024 * 128);
 });
 
 it('sets the map resource limit', function () {
@@ -24,7 +24,7 @@ it('sets the map resource limit', function () {
     $im = $pdf->resourceLimit(ResourceLimitType::Map, 1024 * 1024 * 128)
         ->getImageData($this->testFile, 1);
 
-    expect((int) $im::getResourceLimit(ResourceLimitType::Map->value))->toBe((int) 1024 * 1024 * 128);
+    expect((int) $im::getResourceLimit(ResourceLimitType::Map->value))->toBeGreaterThanOrEqual((int) 1024 * 1024 * 128);
 });
 
 it('sets the memory resource limit', function () {
@@ -32,7 +32,7 @@ it('sets the memory resource limit', function () {
     $im = $pdf->resourceLimit(ResourceLimitType::Memory, 1024 * 1024 * 128)
         ->getImageData($this->testFile, 1);
 
-    expect((int) $im::getResourceLimit(ResourceLimitType::Memory->value))->toBe((int) 1024 * 1024 * 128);
+    expect((int) $im::getResourceLimit(ResourceLimitType::Memory->value))->toBeGreaterThanOrEqual((int) 1024 * 1024 * 128);
 });
 
 it('sets the time resource limit', function () {

--- a/tests/Unit/ResourceLimitsTest.php
+++ b/tests/Unit/ResourceLimitsTest.php
@@ -58,11 +58,3 @@ it('sets the throttle resource limit', function () {
 
     expect((int) $im::getResourceLimit(ResourceLimitType::Throttle->value))->toBe((int) 10);
 });
-
-it('sets the thread resource limit', function () {
-    $pdf = new Pdf($this->testFile);
-    $im = $pdf->resourceLimit(ResourceLimitType::Thread, 1)
-        ->getImageData($this->testFile, 1);
-
-    expect((int)$im::getResourceLimit(ResourceLimitType::Thread->value))->toBe((int)1);
-})->skip(getenv('CI'), 'Skip in CI environments');

--- a/tests/Unit/ResourceLimitsTest.php
+++ b/tests/Unit/ResourceLimitsTest.php
@@ -65,4 +65,4 @@ it('sets the thread resource limit', function () {
         ->getImageData($this->testFile, 1);
 
     expect((int)$im::getResourceLimit(ResourceLimitType::Thread->value))->toBe((int)1);
-});
+})->skip(getenv('CI'), 'Skip in CI environments');

--- a/tests/Unit/ResourceLimitsTest.php
+++ b/tests/Unit/ResourceLimitsTest.php
@@ -1,14 +1,14 @@
 <?php
 
-use Spatie\PdfToImage\Pdf;
 use Spatie\PdfToImage\Enums\ResourceLimitType;
+use Spatie\PdfToImage\Pdf;
 
 it('sets the area resource limit', function () {
     $pdf = new Pdf($this->testFile);
     $im = $pdf->resourceLimit(ResourceLimitType::Area, 1024 * 1024 * 16)
         ->getImageData($this->testFile, 1);
 
-    expect((int)$im::getResourceLimit(ResourceLimitType::Area->value))->toBe((int)1024*1024*16);
+    expect((int) $im::getResourceLimit(ResourceLimitType::Area->value))->toBe((int) 1024 * 1024 * 16);
 });
 
 it('sets the disk resource limit', function () {
@@ -16,7 +16,7 @@ it('sets the disk resource limit', function () {
     $im = $pdf->resourceLimit(ResourceLimitType::Disk, 1024 * 1024)
         ->getImageData($this->testFile, 1);
 
-    expect((int)$im::getResourceLimit(ResourceLimitType::Disk->value))->toBe((int)1024*1024);
+    expect((int) $im::getResourceLimit(ResourceLimitType::Disk->value))->toBe((int) 1024 * 1024);
 });
 
 it('sets the file resource limit', function () {
@@ -24,24 +24,23 @@ it('sets the file resource limit', function () {
     $im = $pdf->resourceLimit(ResourceLimitType::File, 5)
         ->getImageData($this->testFile, 1);
 
-    expect((int)$im::getResourceLimit(ResourceLimitType::File->value))->toBe((int)5);
+    expect((int) $im::getResourceLimit(ResourceLimitType::File->value))->toBe((int) 5);
 });
-
 
 it('sets the map resource limit', function () {
     $pdf = new Pdf($this->testFile);
-    $im = $pdf->resourceLimit(ResourceLimitType::Map, 1024 * 1024*16)
+    $im = $pdf->resourceLimit(ResourceLimitType::Map, 1024 * 1024 * 16)
         ->getImageData($this->testFile, 1);
 
-    expect((int)$im::getResourceLimit(ResourceLimitType::Map->value))->toBe((int)1024*1024*16);
+    expect((int) $im::getResourceLimit(ResourceLimitType::Map->value))->toBe((int) 1024 * 1024 * 16);
 });
 
 it('sets the memory resource limit', function () {
     $pdf = new Pdf($this->testFile);
-    $im = $pdf->resourceLimit(ResourceLimitType::Memory, 1024 * 1024*32)
+    $im = $pdf->resourceLimit(ResourceLimitType::Memory, 1024 * 1024 * 32)
         ->getImageData($this->testFile, 1);
 
-    expect((int)$im::getResourceLimit(ResourceLimitType::Memory->value))->toBe((int)1024*1024*32);
+    expect((int) $im::getResourceLimit(ResourceLimitType::Memory->value))->toBe((int) 1024 * 1024 * 32);
 });
 
 it('sets the time resource limit', function () {
@@ -49,7 +48,7 @@ it('sets the time resource limit', function () {
     $im = $pdf->resourceLimit(ResourceLimitType::Time, 10)
         ->getImageData($this->testFile, 1);
 
-    expect((int)$im::getResourceLimit(ResourceLimitType::Time->value))->toBe((int)10);
+    expect((int) $im::getResourceLimit(ResourceLimitType::Time->value))->toBe((int) 10);
 });
 
 it('sets the throttle resource limit', function () {
@@ -57,7 +56,7 @@ it('sets the throttle resource limit', function () {
     $im = $pdf->resourceLimit(ResourceLimitType::Throttle, 10)
         ->getImageData($this->testFile, 1);
 
-    expect((int)$im::getResourceLimit(ResourceLimitType::Throttle->value))->toBe((int)10);
+    expect((int) $im::getResourceLimit(ResourceLimitType::Throttle->value))->toBe((int) 10);
 });
 
 it('sets the thread resource limit', function () {
@@ -65,6 +64,5 @@ it('sets the thread resource limit', function () {
     $im = $pdf->resourceLimit(ResourceLimitType::Thread, 4)
         ->getImageData($this->testFile, 1);
 
-    expect((int)$im::getResourceLimit(ResourceLimitType::Thread->value))->toBe((int)4);
+    expect((int) $im::getResourceLimit(ResourceLimitType::Thread->value))->toBe((int) 4);
 });
-

--- a/tests/Unit/ResourceLimitsTest.php
+++ b/tests/Unit/ResourceLimitsTest.php
@@ -12,7 +12,7 @@ it('sets the area resource limit', function () {
     $im = $pdf->resourceLimit(ResourceLimitType::Area, $this->memory128MbInBytes)
         ->getImageData($this->testFile, 1);
 
-    expect((int) $im::getResourceLimit(ResourceLimitType::Area->value))->toBeGreaterThanOrEqual($this->memory128MbInBytes);
+    expect((int) $im::getResourceLimit(ResourceLimitType::Area->value))->toEqual($this->memory128MbInBytes);
 });
 
 it('sets the disk resource limit', function () {
@@ -20,7 +20,7 @@ it('sets the disk resource limit', function () {
     $im = $pdf->resourceLimit(ResourceLimitType::Disk, $this->memory128MbInBytes)
         ->getImageData($this->testFile, 1);
 
-    expect((int) $im::getResourceLimit(ResourceLimitType::Disk->value))->toBeGreaterThanOrEqual($this->memory128MbInBytes);
+    expect((int) $im::getResourceLimit(ResourceLimitType::Disk->value))->toEqual($this->memory128MbInBytes);
 });
 
 it('sets the map resource limit', function () {
@@ -28,7 +28,7 @@ it('sets the map resource limit', function () {
     $im = $pdf->resourceLimit(ResourceLimitType::Map, $this->memory128MbInBytes)
         ->getImageData($this->testFile, 1);
 
-    expect((int) $im::getResourceLimit(ResourceLimitType::Map->value))->toBeGreaterThanOrEqual($this->memory128MbInBytes);
+    expect((int) $im::getResourceLimit(ResourceLimitType::Map->value))->toEqual($this->memory128MbInBytes);
 });
 
 it('sets the memory resource limit', function () {
@@ -36,7 +36,7 @@ it('sets the memory resource limit', function () {
     $im = $pdf->resourceLimit(ResourceLimitType::Memory, $this->memory128MbInBytes)
         ->getImageData($this->testFile, 1);
 
-    expect((int) $im::getResourceLimit(ResourceLimitType::Memory->value))->toBeGreaterThanOrEqual($this->memory128MbInBytes);
+    expect((int) $im::getResourceLimit(ResourceLimitType::Memory->value))->toEqual($this->memory128MbInBytes);
 });
 
 it('sets the time resource limit', function () {

--- a/tests/Unit/ResourceLimitsTest.php
+++ b/tests/Unit/ResourceLimitsTest.php
@@ -4,7 +4,7 @@ use Spatie\PdfToImage\Enums\ResourceLimitType;
 use Spatie\PdfToImage\Pdf;
 
 beforeEach(function () {
-    $this->memory128MbInBytes = 134217728;
+    $this->memory128MbInBytes = 128000000;
 });
 
 it('sets the area resource limit', function () {

--- a/tests/Unit/ResourceLimitsTest.php
+++ b/tests/Unit/ResourceLimitsTest.php
@@ -61,8 +61,8 @@ it('sets the throttle resource limit', function () {
 
 it('sets the thread resource limit', function () {
     $pdf = new Pdf($this->testFile);
-    $im = $pdf->resourceLimit(ResourceLimitType::Thread, 4)
+    $im = $pdf->resourceLimit(ResourceLimitType::Thread, 1)
         ->getImageData($this->testFile, 1);
 
-    expect((int) $im::getResourceLimit(ResourceLimitType::Thread->value))->toBe((int) 4);
+    expect((int)$im::getResourceLimit(ResourceLimitType::Thread->value))->toBe((int)1);
 });

--- a/tests/Unit/ResourceLimitsTest.php
+++ b/tests/Unit/ResourceLimitsTest.php
@@ -5,56 +5,40 @@ use Spatie\PdfToImage\Pdf;
 
 it('sets the area resource limit', function () {
     $pdf = new Pdf($this->testFile);
-    $im = $pdf->resourceLimit(ResourceLimitType::Area, 1024 * 1024 * 16)
+    $im = $pdf->resourceLimit(ResourceLimitType::Area, 1024 * 1024 * 128)
         ->getImageData($this->testFile, 1);
 
-    expect((int) $im::getResourceLimit(ResourceLimitType::Area->value))->toBe((int) 1024 * 1024 * 16);
+    expect((int) $im::getResourceLimit(ResourceLimitType::Area->value))->toBe((int) 1024 * 1024 * 128);
 });
 
 it('sets the disk resource limit', function () {
     $pdf = new Pdf($this->testFile);
-    $im = $pdf->resourceLimit(ResourceLimitType::Disk, 1024 * 1024)
+    $im = $pdf->resourceLimit(ResourceLimitType::Disk, 1024 * 1024 * 128)
         ->getImageData($this->testFile, 1);
 
-    expect((int) $im::getResourceLimit(ResourceLimitType::Disk->value))->toBe((int) 1024 * 1024);
-});
-
-it('sets the file resource limit', function () {
-    $pdf = new Pdf($this->testFile);
-    $im = $pdf->resourceLimit(ResourceLimitType::File, 5)
-        ->getImageData($this->testFile, 1);
-
-    expect((int) $im::getResourceLimit(ResourceLimitType::File->value))->toBe((int) 5);
+    expect((int) $im::getResourceLimit(ResourceLimitType::Disk->value))->toBe((int) 1024 * 1024 * 128);
 });
 
 it('sets the map resource limit', function () {
     $pdf = new Pdf($this->testFile);
-    $im = $pdf->resourceLimit(ResourceLimitType::Map, 1024 * 1024 * 16)
+    $im = $pdf->resourceLimit(ResourceLimitType::Map, 1024 * 1024 * 128)
         ->getImageData($this->testFile, 1);
 
-    expect((int) $im::getResourceLimit(ResourceLimitType::Map->value))->toBe((int) 1024 * 1024 * 16);
+    expect((int) $im::getResourceLimit(ResourceLimitType::Map->value))->toBe((int) 1024 * 1024 * 128);
 });
 
 it('sets the memory resource limit', function () {
     $pdf = new Pdf($this->testFile);
-    $im = $pdf->resourceLimit(ResourceLimitType::Memory, 1024 * 1024 * 32)
+    $im = $pdf->resourceLimit(ResourceLimitType::Memory, 1024 * 1024 * 128)
         ->getImageData($this->testFile, 1);
 
-    expect((int) $im::getResourceLimit(ResourceLimitType::Memory->value))->toBe((int) 1024 * 1024 * 32);
+    expect((int) $im::getResourceLimit(ResourceLimitType::Memory->value))->toBe((int) 1024 * 1024 * 128);
 });
 
 it('sets the time resource limit', function () {
     $pdf = new Pdf($this->testFile);
-    $im = $pdf->resourceLimit(ResourceLimitType::Time, 10)
+    $im = $pdf->resourceLimit(ResourceLimitType::Time, 30)
         ->getImageData($this->testFile, 1);
 
-    expect((int) $im::getResourceLimit(ResourceLimitType::Time->value))->toBe((int) 10);
-});
-
-it('sets the throttle resource limit', function () {
-    $pdf = new Pdf($this->testFile);
-    $im = $pdf->resourceLimit(ResourceLimitType::Throttle, 10)
-        ->getImageData($this->testFile, 1);
-
-    expect((int) $im::getResourceLimit(ResourceLimitType::Throttle->value))->toBe((int) 10);
+    expect((int) $im::getResourceLimit(ResourceLimitType::Time->value))->toBe((int) 30);
 });

--- a/tests/Unit/ResourceLimitsTest.php
+++ b/tests/Unit/ResourceLimitsTest.php
@@ -1,0 +1,70 @@
+<?php
+
+use Spatie\PdfToImage\Pdf;
+use Spatie\PdfToImage\Enums\ResourceLimitType;
+
+it('sets the area resource limit', function () {
+    $pdf = new Pdf($this->testFile);
+    $im = $pdf->resourceLimit(ResourceLimitType::Area, 1024 * 1024 * 16)
+        ->getImageData($this->testFile, 1);
+
+    expect((int)$im::getResourceLimit(ResourceLimitType::Area->value))->toBe((int)1024*1024*16);
+});
+
+it('sets the disk resource limit', function () {
+    $pdf = new Pdf($this->testFile);
+    $im = $pdf->resourceLimit(ResourceLimitType::Disk, 1024 * 1024)
+        ->getImageData($this->testFile, 1);
+
+    expect((int)$im::getResourceLimit(ResourceLimitType::Disk->value))->toBe((int)1024*1024);
+});
+
+it('sets the file resource limit', function () {
+    $pdf = new Pdf($this->testFile);
+    $im = $pdf->resourceLimit(ResourceLimitType::File, 5)
+        ->getImageData($this->testFile, 1);
+
+    expect((int)$im::getResourceLimit(ResourceLimitType::File->value))->toBe((int)5);
+});
+
+
+it('sets the map resource limit', function () {
+    $pdf = new Pdf($this->testFile);
+    $im = $pdf->resourceLimit(ResourceLimitType::Map, 1024 * 1024*16)
+        ->getImageData($this->testFile, 1);
+
+    expect((int)$im::getResourceLimit(ResourceLimitType::Map->value))->toBe((int)1024*1024*16);
+});
+
+it('sets the memory resource limit', function () {
+    $pdf = new Pdf($this->testFile);
+    $im = $pdf->resourceLimit(ResourceLimitType::Memory, 1024 * 1024*32)
+        ->getImageData($this->testFile, 1);
+
+    expect((int)$im::getResourceLimit(ResourceLimitType::Memory->value))->toBe((int)1024*1024*32);
+});
+
+it('sets the time resource limit', function () {
+    $pdf = new Pdf($this->testFile);
+    $im = $pdf->resourceLimit(ResourceLimitType::Time, 10)
+        ->getImageData($this->testFile, 1);
+
+    expect((int)$im::getResourceLimit(ResourceLimitType::Time->value))->toBe((int)10);
+});
+
+it('sets the throttle resource limit', function () {
+    $pdf = new Pdf($this->testFile);
+    $im = $pdf->resourceLimit(ResourceLimitType::Throttle, 10)
+        ->getImageData($this->testFile, 1);
+
+    expect((int)$im::getResourceLimit(ResourceLimitType::Throttle->value))->toBe((int)10);
+});
+
+it('sets the thread resource limit', function () {
+    $pdf = new Pdf($this->testFile);
+    $im = $pdf->resourceLimit(ResourceLimitType::Thread, 4)
+        ->getImageData($this->testFile, 1);
+
+    expect((int)$im::getResourceLimit(ResourceLimitType::Thread->value))->toBe((int)4);
+});
+


### PR DESCRIPTION
This PR adds the `resourceLimit()` method and associated Enum class. This method enables setting the various resource limits for Imagemagick, such as memory limits, time limits, and others.

Additionally, it updates the README to document the updated API and adds information on how to fix Imagemagick failures that do not produce an error message.