### PR TITLE
Add background color setting for the output image

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,19 @@ $pdf->layerMethod(\Spatie\PdfToImage\Enums\LayerMethod::Merge);
 $pdf->layerMethod(\Spatie\PdfToImage\Enums\LayerMethod::None);
 ```
 
+Set the background color of the output image:
+
+```php
+$pdf->backgroundColor('white') // simple text for 'white' color
+    ->save($pathToWhereImageShouldBeStored);
+
+$pdf->backgroundColor('#fff') // code for 'white' color
+    ->save($pathToWhereImageShouldBeStored);
+
+$pdf->backgroundColor('rgb(255,255,255)') // rgb for 'white' color
+    ->save($pathToWhereImageShouldBeStored);
+```
+
 ## Issues regarding Ghostscript
 
 This package uses Ghostscript through Imagick. For this to work Ghostscripts `gs` command should be accessible from the PHP process. For the PHP CLI process (e.g. Laravel's asynchronous jobs, commands, etc...) this is usually already the case. 

--- a/src/Pdf.php
+++ b/src/Pdf.php
@@ -12,12 +12,15 @@ use Spatie\PdfToImage\Exceptions\InvalidQuality;
 use Spatie\PdfToImage\Exceptions\InvalidSize;
 use Spatie\PdfToImage\Exceptions\PageDoesNotExist;
 use Spatie\PdfToImage\Exceptions\PdfDoesNotExist;
+use ImagickPixel;
 
 class Pdf
 {
     protected string $filename;
 
     protected int $resolution = 144;
+
+    protected ?string $backgroundColor = null;
 
     protected OutputFormat $outputFormat = OutputFormat::Jpg;
 
@@ -57,6 +60,16 @@ class Pdf
     public function resolution(int $dpiResolution): static
     {
         $this->resolution = $dpiResolution;
+
+        return $this;
+    }
+
+    /**
+     * Set the background color e.g. 'white', '#fff', 'rgb(255, 255, 255)'
+     */
+    public function backgroundColor(string $backgroundColorCode): static
+    {
+        $this->backgroundColor = $backgroundColorCode;
 
         return $this;
     }
@@ -233,6 +246,11 @@ class Pdf
         }
 
         $this->imagick->readImage(sprintf('%s[%s]', $this->filename, $pageNumber - 1));
+
+        if ($this->backgroundColor !== null) {
+            $this->imagick->setImageBackgroundColor(new ImagickPixel($this->backgroundColor));
+            $this->imagick->setImageAlphaChannel(Imagick::ALPHACHANNEL_REMOVE);
+        }
 
         if ($this->resizeWidth !== null) {
             $this->imagick->resizeImage($this->resizeWidth, $this->resizeHeight ?? 0, Imagick::FILTER_POINT, 0);

--- a/src/Pdf.php
+++ b/src/Pdf.php
@@ -247,7 +247,7 @@ class Pdf
 
         $this->imagick->readImage(sprintf('%s[%s]', $this->filename, $pageNumber - 1));
 
-        if ($this->backgroundColor !== null) {
+        if (! empty($this->backgroundColor)) {
             $this->imagick->setImageBackgroundColor(new ImagickPixel($this->backgroundColor));
             $this->imagick->setImageAlphaChannel(Imagick::ALPHACHANNEL_REMOVE);
         }

--- a/tests/Unit/PdfTest.php
+++ b/tests/Unit/PdfTest.php
@@ -48,3 +48,15 @@ it('can select multiple pages', function () {
 
     expect($imagick1)->toBeInstanceOf(Imagick::class);
 });
+
+it('can set the background color', function ($backgroundColor) {
+    $image = (new Pdf($this->testFile))
+        ->backgroundColor($backgroundColor)
+        ->selectPage(1)
+        ->getImageData('page-1.jpg', 1)
+        ->getImageBackgroundColor()
+        ->getColorAsString();
+
+    $expectedSRGBValueForWhiteColor = 'srgb(255,255,255)';
+    expect($image)->toEqual($expectedSRGBValueForWhiteColor);
+})->with(['srgb(255,255,255)', 'rgb(255,255,255)', 'white', '#fff']);


### PR DESCRIPTION
This PR adds the backgroundColor() method. This method enables setting the background color of the output image with color code in various format like rgb(255,255,255), #fff , 'white'.

Also added unit tests and updated to README.md for this new method.