### PR TITLE
fix: use white background by default when flattening PDF layers

### DIFF
--- a/src/Pdf.php
+++ b/src/Pdf.php
@@ -259,8 +259,10 @@ class Pdf
 
         $this->imagick->readImage(sprintf('%s[%s]', $this->filename, $pageNumber - 1));
 
-        if (! empty($this->backgroundColor)) {
-            $this->imagick->setImageBackgroundColor(new ImagickPixel($this->backgroundColor));
+        $backgroundColor = $this->backgroundColor ?? ($this->layerMethod !== LayerMethod::None ? 'white' : null);
+
+        if (! empty($backgroundColor)) {
+            $this->imagick->setImageBackgroundColor(new ImagickPixel($backgroundColor));
             $this->imagick->setImageAlphaChannel(Imagick::ALPHACHANNEL_REMOVE);
         }
 

--- a/tests/Unit/PdfTest.php
+++ b/tests/Unit/PdfTest.php
@@ -57,6 +57,15 @@ it('can set the background color', function ($backgroundColor) {
         ->getImageBackgroundColor()
         ->getColorAsString();
 
-    $expectedSRGBValueForWhiteColor = 'srgb(255,255,255)';
-    expect($image)->toEqual($expectedSRGBValueForWhiteColor);
+    expect($image)->toContain('255,255,255');
 })->with(['srgb(255,255,255)', 'rgb(255,255,255)', 'white', '#fff']);
+
+it('uses white background by default when flattening layers', function () {
+    $image = (new Pdf($this->testFile))
+        ->selectPage(1)
+        ->getImageData('page-1.jpg', 1)
+        ->getImageBackgroundColor()
+        ->getColorAsString();
+
+    expect($image)->toContain('255,255,255');
+});


### PR DESCRIPTION
Fixes #265

Imagick's `mergeImageLayers(FLATTEN)` uses black as the default fill, so transparent PDFs were rendering with a black background. This applies a white background before flattening unless the user has already set a custom `backgroundColor` or is using `LayerMethod::None`.